### PR TITLE
Fix Sarif 2 message conversion

### DIFF
--- a/CodeQualityToGitlab/SarifConverters/Converter2.cs
+++ b/CodeQualityToGitlab/SarifConverters/Converter2.cs
@@ -22,7 +22,7 @@ public class Converter2(FileInfo source, string? pathRoot)
 
             if (begin == null)
             {
-                Log.Warning("An issue has no location, skipping: {@Result}", result.Message);
+                Log.Warning("An issue has no location, skipping: {@Result}", result.Message.Text);
                 continue;
             }
 
@@ -31,7 +31,7 @@ public class Converter2(FileInfo source, string? pathRoot)
                 var startLine = begin.PhysicalLocation.Region.StartLine;
                 var cqr = new CodeQuality
                 {
-                    Description = $"{result.RuleId}: {result.Message}",
+                    Description = $"{result.RuleId}: {result.Message.Text}",
                     Severity = GetSeverity(result.Level),
                     Location = new()
                     {


### PR DESCRIPTION
In Sarif 2.0 and 2.1 the error / warning messages are not directly in the `message` element, instead they are in the `message.text` element. See [GitHub documentation](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#result-object) or the [Sarif format specification](https://docs.oasis-open.org/sarif/sarif/v2.1.0/csprd01/sarif-v2.1.0-csprd01.html#_Toc10540897) itself.

Currently the `Converter2` uses `result.Message` as a string, which will simply be converted to `Microsoft.CodeAnalysis.Sarif.Message` (the type's name) always. Instead `result.Message.Text` should be used.

*Note: in Sarif 2 the message text may contain placeholders for arguments. This PR does not resolve injecting those arguments in place of the placeholders, but that could be a further fix / improvement.*