### PR TITLE
Fix suppression check for sarif v2.1

### DIFF
--- a/CodeQualityToGitlab/SarifConverters/Converter2.cs
+++ b/CodeQualityToGitlab/SarifConverters/Converter2.cs
@@ -13,7 +13,7 @@ public class Converter2(FileInfo source, string? pathRoot)
 
         var results = log.Runs
             .SelectMany(x => x.Results)
-            .Where(r => r.Suppressions == null || r.Suppressions.Any());
+            .Where(r => r.Suppressions == null || r.Suppressions.Count == 0);
 
         var cqrs = new List<CodeQuality>();
         foreach (var result in results)

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -78,6 +78,10 @@
         <None Update="codeanalysis.sarif21.json">
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
+        <None Remove="codeanalysis.sarif21suppression.json" />
+        <Content Include="codeanalysis.sarif21suppression.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
     </ItemGroup>
 
 </Project>

--- a/Test/TestSarif.cs
+++ b/Test/TestSarif.cs
@@ -117,4 +117,21 @@ public class TestSarif
                 }
             );
     }
+
+    [Fact]
+    public void TestHandlesSuppressionForSarif21()
+    {
+        var source = new FileInfo("codeanalysis.sarif21suppression.json");
+        var target = new FileInfo(Path.GetTempFileName());
+
+        SarifConverter.ConvertToCodeQuality(source, target);
+
+        var options = JsonSerializerOptions;
+
+        using var r = new StreamReader(target.FullName);
+        var json = r.ReadToEnd();
+        var result = JsonSerializer.Deserialize<List<CodeQuality>>(json, options);
+
+        result.Should().BeEmpty();
+    }
 }

--- a/Test/codeanalysis.sarif21suppression.json
+++ b/Test/codeanalysis.sarif21suppression.json
@@ -1,0 +1,62 @@
+﻿{
+  "version": "2.1.0",
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.4",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "ESLint",
+          "informationUri": "https://eslint.org",
+          "rules": [
+            {
+              "id": "no-unused-vars",
+              "shortDescription": {
+                "text": "disallow unused variables"
+              },
+              "helpUri": "https://eslint.org/docs/rules/no-unused-vars",
+              "properties": {
+                "category": "Variables"
+              }
+            }
+          ]
+        }
+      },
+      "artifacts": [
+        {
+          "location": {
+            "uri": "file:///C:/dev/sarif/sarif-tutorials/samples/Introduction/simple-example.js"
+          }
+        }
+      ],
+      "results": [
+        {
+          "level": "error",
+          "message": {
+            "text": "'x' is assigned a value but never used."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///C:/dev/sarif/sarif-tutorials/samples/Introduction/simple-example.js",
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 5
+                }
+              }
+            }
+          ],
+          "ruleId": "no-unused-vars",
+          "ruleIndex": 0,
+          "suppressions": [
+            {
+              "kind": "inSource"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
For sarif v2.1 the check for disabling warnings was not entirely correct. If warnings were disabled, they still appeared in the gitlab report.